### PR TITLE
環境ごとの設定切替機能を作成

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,32 @@
+from flask import Flask
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+
+from config import config_map
+
+from .routes.auth import auth_bp
+
+db = SQLAlchemy()
+migrate = Migrate()
+
+
+def create_app(config_name: str) -> Flask:
+    """
+    アプリケーションを作成する
+
+    Args:
+        config_name (str): 使用する設定環境
+        例: "development", "production"など
+
+    Returns:
+        Flask: 初期化済みFlaskアプリケーションインスタンス
+    """
+
+    app = Flask(__name__)
+    app.config.from_object(config_map[config_name])
+
+    app.register_blueprint(auth_bp)
+    db.init_app(app)
+    migrate.init_app(app, db)
+
+    return app

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,17 @@
+"""アプリケーションの設定クラスを管理するモジュール"""
+
+from typing import Type
+
+from config.config import Config
+from config.development import DevelopmentConfig
+from config.production import ProductionConfig
+from config.staging import StagingConfig
+from config.testing import TestingConfig
+
+config_map: dict[str, Type[Config]] = {
+    "development": DevelopmentConfig,
+    "production": ProductionConfig,
+    "staging": StagingConfig,
+    "testing": TestingConfig,
+    "default": DevelopmentConfig,
+}

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+class Config:
+    """アプリケーションの基本設定"""
+
+    basedir = Path(__file__).resolve().parent
+
+    DEBUG = True
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config/development.py
+++ b/config/development.py
@@ -1,0 +1,25 @@
+import os
+
+from dotenv import load_dotenv
+
+from config.config import Config
+from utils.constants import DATABASE_URL_MISSING_ERROR, DEVELOPMENT_SECRET_KEY, ENV_DEVELOPMENT_FILE
+
+
+class DevelopmentConfig(Config):
+    """
+    開発環境用の設定を定義
+
+    Raises:
+        RuntimeError: SQLALCHEMY_DATABASE_URI が環境変数として設定されていない場合
+    """
+
+    dotenv_path = Config.basedir / ENV_DEVELOPMENT_FILE
+    load_dotenv(dotenv_path)
+
+    DEBUG = True
+    SECRET_KEY = DEVELOPMENT_SECRET_KEY
+
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if SQLALCHEMY_DATABASE_URI is None:
+        raise RuntimeError(DATABASE_URL_MISSING_ERROR)

--- a/config/development.py
+++ b/config/development.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from config.config import Config
-from utils.constants import DATABASE_URL_MISSING_ERROR, DEVELOPMENT_SECRET_KEY, ENV_DEVELOPMENT_FILE
+from utils.constants import DATABASE_URI_MISSING_ERROR, DEVELOPMENT_SECRET_KEY, ENV_DEVELOPMENT_FILE
 
 
 class DevelopmentConfig(Config):
@@ -22,4 +22,4 @@ class DevelopmentConfig(Config):
 
     SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     if SQLALCHEMY_DATABASE_URI is None:
-        raise RuntimeError(DATABASE_URL_MISSING_ERROR)
+        raise RuntimeError(DATABASE_URI_MISSING_ERROR)

--- a/config/development.py
+++ b/config/development.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from config.config import Config
-from utils.constants import DATABASE_URI_MISSING_ERROR, DEVELOPMENT_SECRET_KEY, ENV_DEVELOPMENT_FILE
+from utils.constants import DATABASE_CONFIG_ERROR, DB_DIALECT, DB_DRIVER, DEVELOPMENT_SECRET_KEY, ENV_DEVELOPMENT_FILE
 
 
 class DevelopmentConfig(Config):
@@ -11,7 +11,7 @@ class DevelopmentConfig(Config):
     開発環境用の設定を定義
 
     Raises:
-        RuntimeError: SQLALCHEMY_DATABASE_URI が環境変数として設定されていない場合
+        RuntimeError: データベース構成に必要な環境変数が不足している場合
     """
 
     dotenv_path = Config.basedir / ENV_DEVELOPMENT_FILE
@@ -20,6 +20,12 @@ class DevelopmentConfig(Config):
     DEBUG = True
     SECRET_KEY = DEVELOPMENT_SECRET_KEY
 
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
-    if SQLALCHEMY_DATABASE_URI is None:
-        raise RuntimeError(DATABASE_URI_MISSING_ERROR)
+    DB_USER = os.getenv("DB_USER")
+    DB_PASSWORD = os.getenv("DB_PASSWORD")
+    DB_HOST = os.getenv("DB_HOST")
+    DB_PORT = os.getenv("DB_PORT")
+    DB_NAME = os.getenv("DB_NAME")
+    if not all([DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME]):
+        raise RuntimeError(DATABASE_CONFIG_ERROR)
+
+    SQLALCHEMY_DATABASE_URI = f"{DB_DIALECT}+{DB_DRIVER}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"

--- a/config/production.py
+++ b/config/production.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from config.config import Config
-from utils.constants import DATABASE_URL_MISSING_ERROR, ENV_PRODUCTION_FILE, SECRET_KEY_MISSING_ERROR
+from utils.constants import DATABASE_URI_MISSING_ERROR, ENV_PRODUCTION_FILE, SECRET_KEY_MISSING_ERROR
 
 
 class ProductionConfig(Config):
@@ -20,10 +20,10 @@ class ProductionConfig(Config):
 
     DEBUG = False
 
-    SECRET_KEY: str | None = os.environ.get("SECRET_KEY")
+    SECRET_KEY = os.environ.get("SECRET_KEY")
     if SECRET_KEY is None:
         raise RuntimeError(SECRET_KEY_MISSING_ERROR)
 
-    SQLALCHEMY_DATABASE_URI: str | None = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     if SQLALCHEMY_DATABASE_URI is None:
-        raise RuntimeError(DATABASE_URL_MISSING_ERROR)
+        raise RuntimeError(DATABASE_URI_MISSING_ERROR)

--- a/config/production.py
+++ b/config/production.py
@@ -20,7 +20,7 @@ class ProductionConfig(Config):
 
     DEBUG = False
 
-    SECRET_KEY = os.environ.get("SECRET_KEY")
+    SECRET_KEY = os.getenv("SECRET_KEY")
     if SECRET_KEY is None:
         raise RuntimeError(SECRET_KEY_MISSING_ERROR)
 

--- a/config/production.py
+++ b/config/production.py
@@ -1,0 +1,29 @@
+import os
+
+from dotenv import load_dotenv
+
+from config.config import Config
+from utils.constants import DATABASE_URL_MISSING_ERROR, ENV_PRODUCTION_FILE, SECRET_KEY_MISSING_ERROR
+
+
+class ProductionConfig(Config):
+    """
+    本番環境用の設定を定義
+
+    Raises:
+        RuntimeError: SECRET_KEY が環境変数として設定されていない場合
+        RuntimeError: SQLALCHEMY_DATABASE_URI が環境変数として設定されていない場合
+    """
+
+    dotenv_path = Config.basedir / ENV_PRODUCTION_FILE
+    load_dotenv(dotenv_path)
+
+    DEBUG = False
+
+    SECRET_KEY: str | None = os.environ.get("SECRET_KEY")
+    if SECRET_KEY is None:
+        raise RuntimeError(SECRET_KEY_MISSING_ERROR)
+
+    SQLALCHEMY_DATABASE_URI: str | None = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if SQLALCHEMY_DATABASE_URI is None:
+        raise RuntimeError(DATABASE_URL_MISSING_ERROR)

--- a/config/production.py
+++ b/config/production.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from config.config import Config
-from utils.constants import DATABASE_URI_MISSING_ERROR, ENV_PRODUCTION_FILE, SECRET_KEY_MISSING_ERROR
+from utils.constants import DATABASE_CONFIG_ERROR, DB_DIALECT, DB_DRIVER, ENV_PRODUCTION_FILE, SECRET_KEY_MISSING_ERROR
 
 
 class ProductionConfig(Config):
@@ -12,7 +12,7 @@ class ProductionConfig(Config):
 
     Raises:
         RuntimeError: SECRET_KEY が環境変数として設定されていない場合
-        RuntimeError: SQLALCHEMY_DATABASE_URI が環境変数として設定されていない場合
+        RuntimeError: データベース構成に必要な環境変数が不足している場合
     """
 
     dotenv_path = Config.basedir / ENV_PRODUCTION_FILE
@@ -24,6 +24,12 @@ class ProductionConfig(Config):
     if SECRET_KEY is None:
         raise RuntimeError(SECRET_KEY_MISSING_ERROR)
 
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
-    if SQLALCHEMY_DATABASE_URI is None:
-        raise RuntimeError(DATABASE_URI_MISSING_ERROR)
+    DB_USER = os.getenv("DB_USER")
+    DB_PASSWORD = os.getenv("DB_PASSWORD")
+    DB_HOST = os.getenv("DB_HOST")
+    DB_PORT = os.getenv("DB_PORT")
+    DB_NAME = os.getenv("DB_NAME")
+    if not all([DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME]):
+        raise RuntimeError(DATABASE_CONFIG_ERROR)
+
+    SQLALCHEMY_DATABASE_URI = f"{DB_DIALECT}+{DB_DRIVER}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"

--- a/config/staging.py
+++ b/config/staging.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from config.config import Config
-from utils.constants import DATABASE_URI_MISSING_ERROR, ENV_STAGING_FILE, SECRET_KEY_MISSING_ERROR
+from utils.constants import DATABASE_CONFIG_ERROR, DB_DIALECT, DB_DRIVER, ENV_STAGING_FILE, SECRET_KEY_MISSING_ERROR
 
 
 class StagingConfig(Config):
@@ -12,7 +12,7 @@ class StagingConfig(Config):
 
     Raises:
         RuntimeError: SECRET_KEY が環境変数として設定されていない場合
-        RuntimeError: SQLALCHEMY_DATABASE_URI が環境変数として設定されていない場合
+        RuntimeError: データベース構成に必要な環境変数が不足している場合
     """
 
     dotenv_path = Config.basedir / ENV_STAGING_FILE
@@ -24,6 +24,12 @@ class StagingConfig(Config):
     if SECRET_KEY is None:
         raise RuntimeError(SECRET_KEY_MISSING_ERROR)
 
-    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
-    if SQLALCHEMY_DATABASE_URI is None:
-        raise RuntimeError(DATABASE_URI_MISSING_ERROR)
+    DB_USER = os.getenv("DB_USER")
+    DB_PASSWORD = os.getenv("DB_PASSWORD")
+    DB_HOST = os.getenv("DB_HOST")
+    DB_PORT = os.getenv("DB_PORT")
+    DB_NAME = os.getenv("DB_NAME")
+    if not all([DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME]):
+        raise RuntimeError(DATABASE_CONFIG_ERROR)
+
+    SQLALCHEMY_DATABASE_URI = f"{DB_DIALECT}+{DB_DRIVER}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"

--- a/config/staging.py
+++ b/config/staging.py
@@ -20,7 +20,7 @@ class StagingConfig(Config):
 
     DEBUG = False
 
-    SECRET_KEY = os.environ.get("SECRET_KEY")
+    SECRET_KEY = os.getenv("SECRET_KEY")
     if SECRET_KEY is None:
         raise RuntimeError(SECRET_KEY_MISSING_ERROR)
 

--- a/config/staging.py
+++ b/config/staging.py
@@ -1,0 +1,29 @@
+import os
+
+from dotenv import load_dotenv
+
+from config.config import Config
+from utils.constants import DATABASE_URL_MISSING_ERROR, ENV_STAGING_FILE, SECRET_KEY_MISSING_ERROR
+
+
+class StagingConfig(Config):
+    """
+    ステージング環境用の設定を定義
+
+    Raises:
+        RuntimeError: SECRET_KEY が環境変数として設定されていない場合
+        RuntimeError: SQLALCHEMY_DATABASE_URI が環境変数として設定されていない場合
+    """
+
+    dotenv_path = Config.basedir / ENV_STAGING_FILE
+    load_dotenv(dotenv_path)
+
+    DEBUG = False
+
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+    if SECRET_KEY is None:
+        raise RuntimeError(SECRET_KEY_MISSING_ERROR)
+
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    if SQLALCHEMY_DATABASE_URI is None:
+        raise RuntimeError(DATABASE_URL_MISSING_ERROR)

--- a/config/staging.py
+++ b/config/staging.py
@@ -3,7 +3,7 @@ import os
 from dotenv import load_dotenv
 
 from config.config import Config
-from utils.constants import DATABASE_URL_MISSING_ERROR, ENV_STAGING_FILE, SECRET_KEY_MISSING_ERROR
+from utils.constants import DATABASE_URI_MISSING_ERROR, ENV_STAGING_FILE, SECRET_KEY_MISSING_ERROR
 
 
 class StagingConfig(Config):
@@ -26,4 +26,4 @@ class StagingConfig(Config):
 
     SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
     if SQLALCHEMY_DATABASE_URI is None:
-        raise RuntimeError(DATABASE_URL_MISSING_ERROR)
+        raise RuntimeError(DATABASE_URI_MISSING_ERROR)

--- a/config/testing.py
+++ b/config/testing.py
@@ -1,0 +1,11 @@
+from config.config import Config
+from utils.constants import SQLITE_MEMORY_DATABASE_URI, TESTING_SECRET_KEY
+
+
+class TestingConfig(Config):
+    """テスト環境用の設定を定義"""
+
+    DEBUG = True
+    TESTING = True
+    SECRET_KEY = TESTING_SECRET_KEY
+    SQLALCHEMY_DATABASE_URI = SQLITE_MEMORY_DATABASE_URI

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,11 @@ mypy==1.15.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1
 platformdirs==4.3.6
+PyMySQL==1.1.1
 python-dotenv==1.0.1
 PyYAML==6.0.2
 SQLAlchemy==2.0.38
+types-Flask-Migrate==4.1.0.20250112
 typing_extensions==4.12.2
 virtualenv==20.29.3
 Werkzeug==3.1.3

--- a/run.py
+++ b/run.py
@@ -1,0 +1,27 @@
+"""
+Flaskアプリケーションのエントリポイント
+
+環境変数を読み込み、各環境の設定でFlaskアプリケーションを作成する
+
+Example:
+    $ python run.py
+"""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from flask import Flask
+
+from app import create_app
+from utils.constants import ENV_FILE
+
+basedir = Path(__file__).resolve().parent
+dotenv_path = basedir / ENV_FILE
+load_dotenv(dotenv_path)
+
+config_name = os.getenv("FLASK_CONFIG", "default")
+app: Flask = create_app(config_name)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0")

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,18 @@
+"""アプリケーションで使用する定数"""
+
+# 環境変数関連
+ENV_FILE = ".env"
+ENV_DEVELOPMENT_FILE = ".env.development"
+ENV_PRODUCTION_FILE = ".env.production"
+ENV_STAGING_FILE = ".env.staging"
+
+# 開発時のシークレットキー
+DEVELOPMENT_SECRET_KEY = "development-secret-key"
+TESTING_SECRET_KEY = "testing-secret-key"
+
+# SQLiteメモリデータベースURI
+SQLITE_MEMORY_DATABASE_URI = "sqlite:///:memory:"
+
+# エラーメッセージ
+DATABASE_URL_MISSING_ERROR = "環境変数にDATABASE_URLが登録されていません"
+SECRET_KEY_MISSING_ERROR = "環境変数にSECRET_KEYが登録されていません"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -10,9 +10,11 @@ ENV_STAGING_FILE = ".env.staging"
 DEVELOPMENT_SECRET_KEY = "development-secret-key"
 TESTING_SECRET_KEY = "testing-secret-key"
 
-# SQLiteメモリデータベースURI
+# データベース関連
+DB_DIALECT = "mysql"
+DB_DRIVER = "pymysql"
 SQLITE_MEMORY_DATABASE_URI = "sqlite:///:memory:"
 
 # エラーメッセージ
-DATABASE_URI_MISSING_ERROR = "環境変数にDATABASE_URIが登録されていません"
+DATABASE_CONFIG_ERROR = "データベース構成に必要な環境変数が不足しています"
 SECRET_KEY_MISSING_ERROR = "環境変数にSECRET_KEYが登録されていません"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -14,5 +14,5 @@ TESTING_SECRET_KEY = "testing-secret-key"
 SQLITE_MEMORY_DATABASE_URI = "sqlite:///:memory:"
 
 # エラーメッセージ
-DATABASE_URL_MISSING_ERROR = "環境変数にDATABASE_URLが登録されていません"
+DATABASE_URI_MISSING_ERROR = "環境変数にDATABASE_URIが登録されていません"
 SECRET_KEY_MISSING_ERROR = "環境変数にSECRET_KEYが登録されていません"


### PR DESCRIPTION
#1 参照

環境ごとの設定でアプリを起動する機能を作成しました。
ご確認をお願いいたします。

①アプリケーションのエントリポイント`run.py`にて`.env`ファイルを読みこんで環境名`config_name`を取得
②`app/__init__.py`の`create_app(config_name)`にて環境に応じたappを作成
　このときconfigディレクトリ以下の各環境の設定を参照する

configディレクトリの構造は以下を想定しています。

```
├── config
│   ├── .env
│   ├── .env.development
│   ├── .env.production
│   ├── .env.staging
│   ├── __init__.py
│   ├── config.py
│   ├── development.py
│   ├── production.py
│   ├── staging.py
│   └── testing.py
```

「.env」には使用する環境の名前を設定する想定です。

.env 例
`FLASK_CONFIG=development`

「.env.*」に環境ごとのデータベース接続文字列とシークレット値を設定する想定です。

.env.production 例
```
SQLALCHEMY_DATABASE_URI=mysql+pymysql://username:password@hostname:3306/dbname
SECRET_KEY=secret_key_token_for_production
```

以上、よろしくお願いいたします。
